### PR TITLE
getToken will now return a boolean instead of abort()

### DIFF
--- a/src/jc21/PlexApi.php
+++ b/src/jc21/PlexApi.php
@@ -147,7 +147,7 @@ class PlexApi {
     }
 
     /**
-     * Tests credentials and returns the auth token
+     * Tests the set username and password and returns the auth token
      *
      * @return string
      */
@@ -157,7 +157,7 @@ class PlexApi {
         {
             return $this->token;
         }
-        return abort(401);
+        return false;
     }
 
     /**


### PR DESCRIPTION
I had returned an abort(#) call by habit, which won't be supported outside of certain frameworks. I have replaced that with a boolean and clarified the dockblock.