### PR TITLE
Fixes and updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .idea
 vendor
 composer.lock
-.env
+*.env
+*.cache

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     },
     "require-dev": {
         "victorjonsson/markdowndocs": "dev-master",
-        "symfony/dotenv": "6.2.x-dev"
+        "symfony/dotenv": "6.2.x-dev",
+        "phpunit/phpunit": "^9"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,8 @@
         "psr-0": {
             "jc21": "src"
         }
+    },
+    "scripts": {
+        "test": "php vendor/bin/phpunit"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,12 @@
             "email": "jc@jc21.com"
         }
     ],
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "require": {
         "php": ">=7.4",
         "ext-curl": "*"
     },
     "require-dev": {
-        "victorjonsson/markdowndocs": "dev-master",
         "symfony/dotenv": "6.2.x-dev",
         "phpunit/phpunit": "^9"
     },

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,8 @@
         }
     },
     "scripts": {
-        "test": "php vendor/bin/phpunit"
+        "test": "php vendor/bin/phpunit",
+        "sections": "php tests/SectionList.php",
+        "items": "php tests/ItemList.php"
     }
 }

--- a/docs/Album.md
+++ b/docs/Album.md
@@ -40,5 +40,6 @@ The object to represent a music album
 | public        | <strong>__construct()</strong>: <em>void</em><br />                                                                                      |
 | public        | <strong>__get(</strong><em>string</em> <strong>$var)</strong>: <em>mixed</em><br />Magic getter                                          |
 | public        | <strong>__set(</strong><em>string</em> <strong>\$var</strong>, <em>mixed</em> <strong>$val)</strong>: <em>void</em><br />Magic setter    |
+| public | <strong>getChildren()</strong>: <em>ItemCollection:Track</em><br />Method to retrieve collection of tracks on this album |
 | public        | <strong>addTrack(</strong><em>Track</em> <strong>$a)</strong>: <em>void</em>                                                             |
 | public static | <strong>fromLibrary(</strong><em>array</em> <strong>$library)</strong>: <em>Album</em><br />Create a Album from the Plex API call return |

--- a/docs/Album.md
+++ b/docs/Album.md
@@ -1,0 +1,44 @@
+# Album
+
+The object to represent a music album
+
+## Property List
+
+| Data type | Property                | Description                                         |
+| :-------- | :---------------------- | :-------------------------------------------------- |
+| int       | ratingKey               |                                                     |
+| int       | parentRatingKey         |                                                     |
+| string    | key                     | The key to get the details of the album             |
+| string    | parentKey               | The link back to the artist                         |
+| string    | guid                    |                                                     |
+| string    | parentGuid              |                                                     |
+| string    | studio                  | The studio that produced the album                  |
+| string    | type                    | The media type `album`                              |
+| string    | title                   | The title of the album                              |
+| string    | titleSort               | The title used in sorting the album in the UI       |
+| string    | parentTitle             | The name of the parent artist                       |
+| string    | summary                 |                                                     |
+| string    | rating                  | User rating                                         |
+| int       | index                   |                                                     |
+| int       | viewCount               |                                                     |
+| int       | skipCount               |                                                     |
+| int       | year                    | The year the album was released                     |
+| DateTime  | lastVeiwedAt            | Date/time the album was last played                 |
+| DateTime  | originallyAvailableAt   | The date/time the album was released                |
+| DateTime  | addedAt                 | Date/time the album was added to the library        |
+| DateTime  | updatedAt               | Date/time the album database entry was last changed |
+| string    | thumb                   | URL to thumbnail                                    |
+| string    | parentThumb             | URL to artist thumbnail                             |
+| int       | loudnessAnalysisVersion |                                                     |
+| array     | directory               |                                                     |
+| array     | genre                   | Genre's of music on the album                       |
+
+## Function List
+
+| Visibility    | Function (parameters,...): return                                                                                                        |
+| :------------ | :--------------------------------------------------------------------------------------------------------------------------------------- |
+| public        | <strong>__construct()</strong>: <em>void</em><br />                                                                                      |
+| public        | <strong>__get(</strong><em>string</em> <strong>$var)</strong>: <em>mixed</em><br />Magic getter                                          |
+| public        | <strong>__set(</strong><em>string</em> <strong>\$var</strong>, <em>mixed</em> <strong>$val)</strong>: <em>void</em><br />Magic setter    |
+| public        | <strong>addTrack(</strong><em>Track</em> <strong>$a)</strong>: <em>void</em>                                                             |
+| public static | <strong>fromLibrary(</strong><em>array</em> <strong>$library)</strong>: <em>Album</em><br />Create a Album from the Plex API call return |

--- a/docs/Artist.md
+++ b/docs/Artist.md
@@ -1,0 +1,33 @@
+# Artist
+
+The object to represent a music artist
+
+## Property List
+
+| Data type | Property     | Description                                         |
+| :-------- | :----------- | :-------------------------------------------------- |
+| int       | ratingKey    |                                                     |
+| string    | key          | The key to get the details of the artist            |
+| string    | guid         |                                                     |
+| string    | type         | The media type `artist`                             |
+| string    | title        | The artist's name                                   |
+| string    | summary      |                                                     |
+| int       | index        |                                                     |
+| int       | viewCount    | Number of times the artist details have been viewed |
+| int       | skipCount    |                                                     |
+| DateTime  | lastViewedAt | Date/time somebody viewed this artist               |
+| DateTime  | addedAt      | Date/time this artist was added to the database     |
+| DateTime  | updatedAt    | Date/time this artist's database entry was updated  |
+| string    | thumb        | URL to thumbnail image                              |
+| string    | art          |                                                     |
+| array     | genre        | Genre's of music the artist has performed in        |
+| array     | country      | Country's the albums were recorded in               |
+
+## Function List
+| Visibility    | Function (parameters,...): return                                                                                                          |
+| :------------ | :----------------------------------------------------------------------------------------------------------------------------------------- |
+| public        | <strong>__construct()</strong>: <em>void</em><br />                                                                                        |
+| public        | <strong>__get(</strong><em>string</em> <strong>$var)</strong>: <em>mixed</em><br />Magic getter                                            |
+| public        | <strong>__set(</strong><em>string</em> <strong>\$var</strong>, <em>mixed</em> <strong>$val)</strong>: <em>void</em><br />Magic setter      |
+| public        | <strong>addAlbum(</strong><em>Album</em> <strong>$a)</strong>: <em>void</em>                                                               |
+| public static | <strong>fromLibrary(</strong><em>array</em> <strong>$library)</strong>: <em>Artist</em><br />Create a Artist from the Plex API call return |

--- a/docs/Artist.md
+++ b/docs/Artist.md
@@ -29,5 +29,6 @@ The object to represent a music artist
 | public        | <strong>__construct()</strong>: <em>void</em><br />                                                                                        |
 | public        | <strong>__get(</strong><em>string</em> <strong>$var)</strong>: <em>mixed</em><br />Magic getter                                            |
 | public        | <strong>__set(</strong><em>string</em> <strong>\$var</strong>, <em>mixed</em> <strong>$val)</strong>: <em>void</em><br />Magic setter      |
-| public        | <strong>addAlbum(</strong><em>Album</em> <strong>$a)</strong>: <em>void</em>                                                               |
+| public | <strong>getChildren()</strong>: <em>ItemCollection:Album</em><br />Method to retrieve all albums written by this artist |
+| public        | <strong>addAlbum(</strong><em>Album</em> <strong>$a)</strong>: <em>void</em> |
 | public static | <strong>fromLibrary(</strong><em>array</em> <strong>$library)</strong>: <em>Artist</em><br />Create a Artist from the Plex API call return |

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -2,7 +2,7 @@
 
 ### Main Class
 
-[PlexApi](PlexApi.md)<br />
+[PlexApi](PlexApi.md)
 
 ### Collection Classes
 
@@ -11,13 +11,16 @@
 
 ### Media Classes
 
-[Movie](Movie.md)<br />
-[Show](Show.md)<br />
-[Season](Season.md)<br />
-[Episode](Episode.md)<br />
-[Artist](Artist.md)<br />
-[Album](Album.md)<br />
-[Track](Track.md)<br />
+- Movie
+  - [Movie](Movie.md)<br />
+- TV
+  - [Show](Show.md)<br />
+  - [Season](Season.md)<br />
+  - [Episode](Episode.md)<br />
+- Music
+  - [Artist](Artist.md)<br />
+  - [Album](Album.md)<br />
+  - [Track](Track.md)<br />
 
 ### Utility Classes
 

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -15,6 +15,9 @@
 [Show](Show.md)<br />
 [Season](Season.md)<br />
 [Episode](Episode.md)<br />
+[Artist](Artist.md)<br />
+[Album](Album.md)<br />
+[Track](Track.md)<br />
 
 ### Utility Classes
 
@@ -25,6 +28,10 @@ Item - only present for inheritance and `ItemCollection`<br />
 [Media](Media.md)<br />
 [Size](Size.md)<br />
 [Section](Section.md)
+
+### Dev Testing
+
+[Tests](Tests.md)
 
 <hr />
 

--- a/docs/Filter.md
+++ b/docs/Filter.md
@@ -1,11 +1,11 @@
 # Filter
 
-This class is specifically intended to filter a library section, but could be used for other purposes.  Objects are `immutable` as there are no publicly available properties or setter methods.
+This class is specifically intended to filter a library section, but could be used for other purposes.  Objects are `immutable` as there are no publicly available properties or setter methods.  **Filters matches case-insensitive results.**
 
 ## Function List
 
 | Visibility | Function (parameters,...): return |
-|:-----------|:---------|
+| :--------- | :-------------------------------- |
 | public | <strong>__construct(</strong><em>string</em> <strong>$field</strong>, <em>string</em> <strong>$value</strong>, <em>string</em> <strong>$operator = `'='`)</strong>: <em>void</em> |
 | public | <strong>__toString()</strong>: <em>string</em><br />Convert the object to a string |
 

--- a/docs/PlexApi.md
+++ b/docs/PlexApi.md
@@ -2,8 +2,8 @@
 
 ## Function List
 
-| Visibility | Function (parameters,...): return |
-|:-----------|:---------|
+| Visibility       | Function (parameters,...): return |
+| :--------------- | :---------------- |
 | public | <strong>__construct(</strong><em>string</em> <strong>$host = `'127.0.0.1'`</strong>, <em>mixed/int</em> <strong>$port = 32400</strong>, <em>bool</em> <strong>$ssl = false</strong>)</strong> : <em>void</em><br /><em>Instantiate the class with your Host/Port</em> |
 | public | <strong>getBaseInfo()</strong> : <em>array\|bool</em><br /><em>Get Plex Server basic info</em> |
 | public | <strong>getLastCallStats()</strong> : <em>array</em><br /><em>Get last curl stats, for debugging purposes</em> |
@@ -31,4 +31,5 @@
 | private | <strong>buildHttpQuery(</strong><em>array</em> <strong>$query)</strong>: <em>string</em><br /><em>Build http query string from array of `Filter` objects</em> |
 | protected static | <strong>normalizeSimpleXML(</strong><em>mixed</em> <strong>$obj</strong>, <em>mixed</em> <strong>$result</strong>)</strong> : <em>void</em><br /><em>normalizeSimpleXML</em> |
 | protected static | <strong>xml2array(</strong><em>mixed</em> <strong>$xml</strong>)</strong> : <em>mixed</em><br /><em>xml2array</em> |
-| public static | <strong>array2Collection(</strong><em>array</em> <strong>$array)</strong>: <em>ItemCollection</em> |
+| public static | <strong>array2collection(</strong><em>array</em> <strong>$array)</strong>: <em>ItemCollection</em> |
+| public static | <strong>array2object(</strong><em>array</em> <strong>$array)</strong>: <em>Movie/Show/Season/Episode/Artist/Album/Track</em> |

--- a/docs/PlexApi.md
+++ b/docs/PlexApi.md
@@ -11,6 +11,7 @@
 | public | <strong>getLibrarySections()</strong> : <em>array\|bool</em><br /><em>Get Library Sections ie Movies, TV Shows etc</em> |
 | public | <strong>getLibrarySectionContents(</strong><em>int</em> <strong>$sectionKey</strong>, <em>bool</em> <strong>$returnCollection = `false`)</strong> : <em>array\|ItemCollection\|bool</em><br /><em>Get Library Section contents</em> |
 | public | <strong>getMetadata(</strong><em>int</em> <strong>$item</strong>)</strong> : <em>array\|bool</em><br /><em>Get Metadata for an Item</em> |
+| public | <strong>getArtwork(</strong><em>Movie</em> <strong>$item</strong>, <em>string</em> <strong>$tag</strong>) : <em>string</em><br /><em>Get binary data for artwork, can store as `jpg` at return</em> |
 | public | <strong>getOnDeck(</strong><em>bool</em> <strong>$returnCollection = `false`)</strong> : <em>array\|ItemCollection\|bool</em><br /><em>Get On Deck Info</em> |
 | public | <strong>getRecentlyAdded(</strong><em>bool</em> <strong>$returnCollection = `false`)</strong> : <em>array\|ItemCollection\|bool</em><br /><em>Get Recently Added</em> |
 | public | <strong>getServers()</strong> : <em>array\|bool</em><br /><em>Get Servers</em> |

--- a/docs/PlexApi.md
+++ b/docs/PlexApi.md
@@ -4,7 +4,7 @@
 
 | Visibility | Function (parameters,...): return |
 |:-----------|:---------|
-| public | <strong>__construct(</strong><em>string</em> <strong>$host=`'127.0.0.1'`</strong>, <em>mixed/int</em> <strong>$port=32400</strong>, <em>bool</em> <strong>$ssl=false</strong>)</strong> : <em>void</em><br /><em>Instantiate the class with your Host/Port</em> |
+| public | <strong>__construct(</strong><em>string</em> <strong>$host = `'127.0.0.1'`</strong>, <em>mixed/int</em> <strong>$port = 32400</strong>, <em>bool</em> <strong>$ssl = false</strong>)</strong> : <em>void</em><br /><em>Instantiate the class with your Host/Port</em> |
 | public | <strong>getBaseInfo()</strong> : <em>array\|bool</em><br /><em>Get Plex Server basic info</em> |
 | public | <strong>getLastCallStats()</strong> : <em>array</em><br /><em>Get last curl stats, for debugging purposes</em> |
 | public | <strong>getLibrarySections()</strong> : <em>array\|bool</em><br /><em>Get Library Sections ie Movies, TV Shows etc</em> |

--- a/docs/PlexApi.md
+++ b/docs/PlexApi.md
@@ -6,6 +6,7 @@
 | :--------------- | :---------------- |
 | public | <strong>__construct(</strong><em>string</em> <strong>$host = `'127.0.0.1'`</strong>, <em>mixed/int</em> <strong>$port = 32400</strong>, <em>bool</em> <strong>$ssl = false</strong>)</strong> : <em>void</em><br /><em>Instantiate the class with your Host/Port</em> |
 | public | <strong>getBaseInfo()</strong> : <em>array\|bool</em><br /><em>Get Plex Server basic info</em> |
+| public | <strong>getAccount()</strong> : <em>array\|bool</em><br /><em>Get account info</em> |
 | public | <strong>getLastCallStats()</strong> : <em>array</em><br /><em>Get last curl stats, for debugging purposes</em> |
 | public | <strong>getLibrarySections()</strong> : <em>array\|bool</em><br /><em>Get Library Sections ie Movies, TV Shows etc</em> |
 | public | <strong>getLibrarySectionContents(</strong><em>int</em> <strong>$sectionKey</strong>, <em>bool</em> <strong>$returnCollection = `false`)</strong> : <em>array\|ItemCollection\|bool</em><br /><em>Get Library Section contents</em> |
@@ -32,4 +33,4 @@
 | protected static | <strong>normalizeSimpleXML(</strong><em>mixed</em> <strong>$obj</strong>, <em>mixed</em> <strong>$result</strong>)</strong> : <em>void</em><br /><em>normalizeSimpleXML</em> |
 | protected static | <strong>xml2array(</strong><em>mixed</em> <strong>$xml</strong>)</strong> : <em>mixed</em><br /><em>xml2array</em> |
 | public static | <strong>array2collection(</strong><em>array</em> <strong>$array)</strong>: <em>ItemCollection</em> |
-| public static | <strong>array2object(</strong><em>array</em> <strong>$array)</strong>: <em>Movie/Show/Season/Episode/Artist/Album/Track</em> |
+| public static | <strong>array2object(</strong><em>array</em> <strong>$array)</strong>: <em>Movie\|Show\|Season\|Episode\|Artist\|Album\|Track</em> |

--- a/docs/Season.md
+++ b/docs/Season.md
@@ -26,7 +26,7 @@ This represents a single season within a show
 | int | viewedLeafCount | The number of times an episode in this season was viewed |
 | `DateTime` | addedAt | The date and time this season was added to the library |
 | `DateTime` | updatedAt | The date and time this season was last updated in the library |
-| array:[Episode](Episode.md) | episodes | An array to store all the episodes in this season |
+| `ItemCollection`:`Episode`(Episode.md) | episodes | An array to store all the episodes in this season |
 
 ## Function List
 
@@ -35,6 +35,6 @@ This represents a single season within a show
 | public | <strong>__construct()</strong>: <em>void</em><br /> |
 | public | <strong>__get(</strong><em>string</em> <strong>$var)</strong>: <em>mixed</em><br />Magic getter |
 | public | <strong>__set(</strong><em>string</em> <strong>$var</strong>, <em>mixed</em> <strong>$val)</strong>: <em>void</em><br />Magic setter |
-| public | <strong>getEpisodes()</strong>: <em>array:Episodes</em><br />Method to get all episodes within this season |
+| public | <strong>getChildren()</strong>: <em>ItemCollection:Episodes</em><br />Method to get all episodes within this season |
 | public | <strong>addEpisode(</strong><em>Episode</em> <strong>$episode)</strong>: <em>void</em><br />Method to add an episode to the season |
 | public static | <strong>fromLibrary(</strong><em>array</em> <strong>$lib)</strong>: <em>Season</em><br />Method to create a season |

--- a/docs/Show.md
+++ b/docs/Show.md
@@ -34,7 +34,7 @@ A TV Show
 | string | audienceRatingImage |  |
 | array:string | genre | The genres the show is in |
 | array:string | role | The actor/actresses in the show |
-| array:[Season](Season.md) | seasons | The array containing all the seasons |
+| `ItemCollection`:`Season`(Season.md) | seasons | The array containing all the seasons |
 
 ## Function List
 
@@ -43,6 +43,6 @@ A TV Show
 | public | <strong>__construct()</strong>: <em>void</em><br /> |
 | public | <strong>__get(</strong><em>string</em> <strong>$var)</strong>: <em>mixed</em><br />Magic getter |
 | public | <strong>__set(</strong><em>string</em> <strong>$var</strong>, <em>mixed</em> <strong>$val)</strong>: <em>void</em><br />Magic setter |
-| public | <strong>getSeasons()</strong>: <em>array:Season</em><br />Method to get the seasons |
+| public | <strong>getChildren()</strong>: <em>array:Season</em><br />Method to get the seasons |
 | public | <strong>addSeason(</strong><em>Season</em> <strong>$season)</strong>: <em>bool</em><br />Method to add a season to the show |
 | public static | <strong>fromLibrary(</strong><em>array</em> <strong>$lib)</strong>: <em>Show</em><br />Method to create a show from the Plex API call |

--- a/docs/Tests.md
+++ b/docs/Tests.md
@@ -1,0 +1,33 @@
+# Tests
+
+## Intro
+
+PHPUnit is added for development purposes to be able to perform unit tests and make sure that all functions operate as expected.  To accomplish this an `.env` file needs to be created in the `/tests` folder with the following information:
+
+| **Env**                | **Value**      | **Description**                                                            |
+| ---------------------- | -------------- | -------------------------------------------------------------------------- |
+| **PLEX_HOST**          | *ip\|hostname* | IP or host name of the Plex server                                         |
+| **PLEX_PORT**          | *port*         | Port to connect to Plex server (optional, defaults 32400)                  |
+| **PLEX_USER**          | *email*        | Username to login to Plex.tv (only needed once)                            |
+| **PLEX_PASSWORD**      | *password*     | Password to login to Plex.tv (only needed once)                            |
+| **PLEX_SSL**           | *0\|1*         | Boolean to connect to Plex server over SSL                                 |
+| **MOVIE_TESTS**        | *0\|1*         | Boolean to conduct tests on movie library (optional)                       |
+| **MOVIE_SECTION_KEY**  | *int*          | Integer of movie library (run `composer sections` to see list              |
+| **MOVIE_ITEM_ID**      | *int*          | Integer key of a specific movie to pull metadata for                       |
+| **MOVIE_SEARCH_QUERY** | *string*       | String query to search for in Movie library                                |
+| **MOVIE_FILTER_QUERY** | *string*       | String query to filter for in Movie library (must be a 'title')            |
+| **TV_TESTS**           | *0\|1*         | Boolean to conduct tests of TV library (optional)                          |
+| **TV_SECTION_KEY**     | *int*          | Integer of TV library (run `composer sections` to see list)                |
+| **TV_ITEM_ID**         | *int*          | Integer key of a specific TV show, season, or episode to pull metadata for |
+| **TV_SEARCH_QUERY**    | *string*       | String query to search for in TV library                                   |
+| **TV_FILTER_QUERY**    | *string*       | String query to filter for in TV library (must be 'title')                 |
+| **MUSIC_TESTS**        | *0\|1*         | Boolean to conduct tests of Music library (optional)                       |
+| **MUSIC_SECTION_KEY**  | *int*          | Integer of Music library (run `composer sections` to see list              |
+| **MUSIC_SEARCH_QUERY** | *string*       | String query to search for in Music library                                |
+| **MUSIC_FILTER_QUERY** | *string*       | String query to filter for in Music library                                |
+
+The `PLEX_*` values are required. The username and password values can be deleted after the token is retrieved
+
+`*_TESTS` are optional, if they are not present, those tests will not be run.  If they are present, then the similar ENV values are required.
+
+Once you have the PLEX_* values present you can run `composer sections` to retrieve the section keys for your libraries.  Put in the section keys for the tests you want to run.  After you've made the changes, run `composer test` to run php tests

--- a/docs/Track.md
+++ b/docs/Track.md
@@ -1,0 +1,43 @@
+# Track
+
+The object to represent a music track
+
+## Property List
+
+| Data type | Property             | Description                                       |
+| :-------- | :------------------- | :------------------------------------------------ |
+| int       | ratingKey            |                                                   |
+| int       | parentRatingKey      |                                                   |
+| int       | grandparentRatingKey |                                                   |
+| string    | key                  | The key to get the track details                  |
+| string    | parentKey            | The key to get the album details                  |
+| string    | grandparentKey       | The key to get the artist details                 |
+| string    | guid                 |                                                   |
+| string    | parentGuid           |                                                   |
+| string    | grandparentGuid      |                                                   |
+| string    | type                 | The media type `track`                            |
+| string    | title                | The track title                                   |
+| string    | parentTitle          | The album title                                   |
+| string    | grandparentTitle     | The artist name                                   |
+| string    | parentStudio         | The publishing album studio                       |
+| string    | summary              |                                                   |
+| int       | index                |                                                   |
+| int       | parentIndex          |                                                   |
+| int       | ratingCount          |                                                   |
+| int       | parentYear           | The release year                                  |
+| string    | thumb                |                                                   |
+| string    | parentThumb          |                                                   |
+| string    | grandparentThumb     |                                                   |
+| Duration  | duration             |                                                   |
+| DateTime  | addedAt              | The date/time the track was added to the database |
+| DateTime  | updatedAt            | The date/time of track was last updated           |
+| Media     | media                | The details of the media file itself              |
+
+## Function List
+
+| Visibility    | Function (parameters,...): return                                                                                                        |
+| :------------ | :--------------------------------------------------------------------------------------------------------------------------------------- |
+| public        | <strong>__construct()</strong>: <em>void</em><br />                                                                                      |
+| public        | <strong>__get(</strong><em>string</em> <strong>$var)</strong>: <em>mixed</em><br />Magic getter                                          |
+| public        | <strong>__set(</strong><em>string</em> <strong>\$var</strong>, <em>mixed</em> <strong>$val)</strong>: <em>void</em><br />Magic setter    |
+| public static | <strong>fromLibrary(</strong><em>array</em> <strong>$library)</strong>: <em>Album</em><br />Create a Album from the Plex API call return |

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,7 +11,7 @@
   </coverage>
   <testsuites>
     <testsuite name="Tests">
-      <directory suffix=".php">tests/</directory>
+      <directory suffix="Test.php">tests/</directory>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  bootstrap="tests/bootstrap.php" 
+  colors="true" 
+  verbose="true" 
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+  cacheResult="true">
+  <coverage includeUncoveredFiles="true" processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Tests">
+      <directory suffix=".php">tests/</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,10 +2,8 @@
 <phpunit 
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
   bootstrap="tests/bootstrap.php" 
-  colors="true" 
-  verbose="true" 
-  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-  cacheResult="true">
+  colors="true" verbose="true" cacheResult="true"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <coverage includeUncoveredFiles="true" processUncoveredFiles="true">
     <include>
       <directory suffix=".php">src/</directory>

--- a/src/jc21/Collections/ItemCollection.php
+++ b/src/jc21/Collections/ItemCollection.php
@@ -8,6 +8,7 @@ use jc21\Util\Item;
 use jc21\Movies\Movie;
 use jc21\TV\Show;
 use jc21\Iterators\ItemIterator;
+use jc21\Util\Size;
 
 /**
  * Collection to store Items
@@ -37,6 +38,26 @@ class ItemCollection implements IteratorAggregate
     public function count(): int
     {
         return count($this->collection);
+    }
+
+    /**
+     * Get the size of the media in the collection
+     * 
+     * @return Size
+     */
+    public function size(): Size
+    {
+        $int = 0;
+        foreach ($this->collection as $item) {
+            if (method_exists($item, 'getChildren')) {
+                $item->getChildren()->size();
+            }
+            /** @var Movie|Episode|Track $item */
+            $int += (int) $item->media->size->bytes();
+        }
+        $size = new Size($int);        
+
+        return $size;
     }
 
     /**

--- a/src/jc21/Collections/ItemCollection.php
+++ b/src/jc21/Collections/ItemCollection.php
@@ -44,7 +44,7 @@ class ItemCollection implements IteratorAggregate
      *
      * @param int $position
      *
-     * @return null|Movie|Show
+     * @return null|Movie|Show|Season|Episode|Artist|Album|Track
      */
     public function getData(int $position = 0)
     {
@@ -57,6 +57,8 @@ class ItemCollection implements IteratorAggregate
 
     /**
      * Method to add a Item to the collection
+     *
+     * @param Item $Item
      */
     public function addData(Item $Item)
     {

--- a/src/jc21/Movies/Movie.php
+++ b/src/jc21/Movies/Movie.php
@@ -78,7 +78,7 @@ class Movie implements JsonSerializable, Item
             'updatedAt' => null,
             'audienceRatingImage' => null,
             'primaryExtraKey' => null,
-            'media' => new Media(),
+            'media' => null,
             'genre' => [],
             'director' => [],
             'writer' => [],
@@ -126,7 +126,9 @@ class Movie implements JsonSerializable, Item
         $me = new static();
         $me->data = $library;
 
-        $me->data['duration'] = new Duration($library['duration']);
+        if (isset($library['duration'])) {
+            $me->duration = new Duration($library['duration']);
+        }
 
         if (isset($library['lastViewedAt'])) {
             $lastViewedAt = new DateTime();
@@ -137,7 +139,7 @@ class Movie implements JsonSerializable, Item
         $addedAt = new DateTime();
         $addedAt->setTimestamp($library['addedAt']);
         $me->addedAt = $addedAt;
-        
+
         $updatedAt = new DateTime();
         $updatedAt->setTimestamp($library['updatedAt']);
         $me->updatedAt = $updatedAt;
@@ -191,8 +193,17 @@ class Movie implements JsonSerializable, Item
         }
 
         if (isset($library['Media'])) {
-            $media = Media::fromLibrary($library['Media']);
-            $me->media = $media;
+            if (isset($library['Media'][0])) {
+                $arr = [];
+                foreach ($library['Media'] as $m) {
+                    $media = Media::fromLibrary($m);
+                    $arr[] = $media;
+                }
+                $me->media = $arr;
+            } else {
+                $media = Media::fromLibrary($library['Media']);
+                $me->media = $media;
+            }
             unset($me->data['Media']);
         }
 

--- a/src/jc21/Movies/Movie.php
+++ b/src/jc21/Movies/Movie.php
@@ -94,7 +94,7 @@ class Movie implements JsonSerializable, Item
      *
      * @return mixed
      */
-    public function __get(string $var): mixed
+    public function __get(string $var)
     {
         if (isset($this->data[$var])) {
             return $this->data[$var];
@@ -219,7 +219,7 @@ class Movie implements JsonSerializable, Item
      *
      * @return mixed
      */
-    public function jsonSerialize(): mixed
+    public function jsonSerialize()
     {
         return $this->data;
     }

--- a/src/jc21/Music/Album.php
+++ b/src/jc21/Music/Album.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace jc21\Music;
+
+use DateTime;
+use Exception;
+use JsonSerializable;
+use jc21\Util\Item;
+
+/**
+ * Album data
+ *
+ * @property int $ratingKey
+ * @property int $parentRatingKey
+ * @property string $key
+ * @property string $parentKey
+ * @property string $guid
+ * @property string $parentGuid
+ * @property string $studio
+ * @property string $type
+ * @property string $title
+ * @property string $titleSort
+ * @property string $parentTitle
+ * @property string $summary
+ * @property string $rating
+ * @property int $index
+ * @property int $viewCount
+ * @property int $skipCount
+ * @property DateTime $lastViewedAt
+ * @property int $year
+ * @property string $thumb
+ * @property string $parentThumb
+ * @property DateTime $originallyAvailableAt
+ * @property DateTime $addedAt
+ * @property DateTime $updatedAt
+ * @property int $loudnessAnalysisVersion
+ * @property array $directory
+ * @property array $genre
+ */
+class Album implements Item, JsonSerializable
+{
+    /**
+     * Class data
+     *
+     * @var array
+     */
+    private array $data;
+
+    /**
+     * Array to store track data
+     *
+     * @var array
+     */
+    private array $tracks;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->tracks = [];
+    }
+
+    /**
+     * Magic getter
+     *
+     * @param string $var
+     *
+     * @return mixed
+     */
+    public function __get(string $var)
+    {
+        if (isset($this->data[$var])) {
+            return $this->data[$var];
+        }
+        return null;
+    }
+
+    /**
+     * Magic setter
+     *
+     * @param string $var
+     * @param mixed $val
+     */
+    public function __set(string $var, $val)
+    {
+        $this->data[$var] = $val;
+    }
+
+    /**
+     * Add a track to the library
+     *
+     * @param Track $t
+     */
+    public function addTrack(Track $t)
+    {
+        $this->tracks[] = $t;
+    }
+
+    /**
+     * Method to create an object from Plex data
+     *
+     * @param array $lib
+     *
+     * @return Album
+     */
+    public static function fromLibrary(array $lib): Album
+    {
+        if (!isset($GLOBALS['client'])) {
+            throw new Exception('PlexApi client `$client` not available');
+        }
+        global $client;
+
+        $me = new static();
+        $me->data = $lib;
+
+        if (isset($lib['lastViewedAt'])) {
+            $lastViewedAt = new DateTime();
+            $lastViewedAt->setTimestamp($lib['lastViewedAt']);
+            $me->lastViewedAt = $lastViewedAt;
+        }
+
+        if (isset($lib['addedAt'])) {
+            $addedAt = new DateTime();
+            $addedAt->setTimestamp($lib['addedAt']);
+            $me->addedAt = $addedAt;
+        }
+
+        if (isset($lib['updatedAt'])) {
+            $updatedAt = new DateTime();
+            $updatedAt->setTimestamp($lib['updatedAt']);
+            $me->updatedAt = $updatedAt;
+        }
+
+        if (isset($lib['originallyAvailableAt'])) {
+            $me->originallyAvailableAt = new DateTime($lib['originallyAvailableAt']);
+        }
+
+        if (isset($lib['Genre']) && is_array($lib['Genre'])) {
+            if (count($lib['Genre']) == 1) {
+                $me->data['genre'][] = $lib['Genre']['tag'];
+            } else {
+                foreach ($lib['Genre'] as $g) {
+                    $me->data['genre'][] = $g['tag'];
+                }
+            }
+            unset($me->data['Genre']);
+        }
+
+        if (isset($lib['Director']) && is_array($lib['Director'])) {
+            if (count($lib['Director']) == 1) {
+                $me->data['director'][] = $lib['Director']['tag'];
+            } else {
+                foreach ($lib['Director'] as $d) {
+                    $me->data['director'][] = $d['tag'];
+                }
+            }
+            unset($me->data['Director']);
+        }
+
+        $res = $client->call($me->key);
+        if (isset($res['Track']) && is_array($res['Track']) && count($res['Track'])) {
+            if (isset($res['Track'][0])) {
+                foreach ($res['Track'] as $t) {
+                    $track = Track::fromLibrary($t);
+                    $me->addTrack($track);
+                }
+            } else {
+                $track = Track::fromLibrary($res['Track']);
+                $me->addTrack($track);
+            }
+        }
+
+        return $me;
+    }
+
+    /**
+     * Method to serialize the object
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->data;
+    }
+}

--- a/src/jc21/Music/Album.php
+++ b/src/jc21/Music/Album.php
@@ -5,6 +5,7 @@ namespace jc21\Music;
 use DateTime;
 use Exception;
 use JsonSerializable;
+use jc21\Collections\ItemCollection;
 use jc21\Util\Item;
 
 /**
@@ -49,16 +50,16 @@ class Album implements Item, JsonSerializable
     /**
      * Array to store track data
      *
-     * @var array
+     * @var ItemCollection
      */
-    private array $tracks;
+    private ItemCollection $tracks;
 
     /**
      * Constructor
      */
     public function __construct()
     {
-        $this->tracks = [];
+        $this->tracks = new ItemCollection();
     }
 
     /**
@@ -88,13 +89,23 @@ class Album implements Item, JsonSerializable
     }
 
     /**
+     * Method to retrieve tracks on this album
+     * 
+     * @return ItemCollection
+     */
+    public function getChildren(): ItemCollection
+    {
+        return $this->tracks;
+    }
+
+    /**
      * Add a track to the library
      *
      * @param Track $t
      */
     public function addTrack(Track $t)
     {
-        $this->tracks[] = $t;
+        $this->tracks->addData($t);
     }
 
     /**

--- a/src/jc21/Music/Artist.php
+++ b/src/jc21/Music/Artist.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace jc21\Music;
+
+use DateTime;
+use Exception;
+use JsonSerializable;
+use jc21\Util\Item;
+
+/**
+ * Artist
+ *
+ * @property int $ratingKey
+ * @property string $key
+ * @property string $guid
+ * @property string $type
+ * @property string $title
+ * @property string $summary
+ * @property int $index
+ * @property int $viewCount
+ * @property int $skipCount
+ * @property DateTime $lastViewedAt
+ * @property DateTime $addedAt
+ * @property DateTime $updatedAt
+ * @property string $thumb
+ * @property string $art
+ * @property array $genre
+ * @property array $country
+ */
+class Artist implements Item, JsonSerializable
+{
+    /**
+     * Class data
+     *
+     * @var array
+     */
+    private array $data;
+
+    /**
+     * Array to store albums
+     *
+     * @var array:Album
+     */
+    private array $albums;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->albums = [];
+    }
+
+    /**
+     * Magic getter method
+     *
+     * @param string $var
+     *
+     * @return mixed
+     */
+    public function __get(string $var)
+    {
+        if (isset($this->data[$var])) {
+            return $this->data[$var];
+        }
+
+        return null;
+    }
+
+    /**
+     * Magic setter method
+     *
+     * @param string $var
+     * @param mixed $val
+     */
+    public function __set(string $var, $val)
+    {
+        $this->data[$var] = $val;
+    }
+
+    /**
+     * Method to add album
+     *
+     * @param Album $a
+     */
+    public function addAlbum(Album $a)
+    {
+        $this->albums[] = $a;
+    }
+
+    /**
+     * Method to create an object from a library
+     *
+     * @param array $lib
+     *
+     * @return Artist
+     */
+    public static function fromLibrary(array $lib): Artist
+    {
+        if (!isset($GLOBALS['client'])) {
+            throw new Exception('PlexApi client `$client` not available');
+        }
+        global $client;
+
+        $me = new static();
+        $me->data = $lib;
+
+        if (isset($lib['lastViewedAt'])) {
+            $lastViewedAt = new DateTime();
+            $lastViewedAt->setTimestamp($lib['lastViewedAt']);
+            $me->lastViewedAt = $lastViewedAt;
+        }
+
+        if (isset($lib['addedAt'])) {
+            $addedAt = new DateTime();
+            $addedAt->setTimestamp($lib['addedAt']);
+            $me->addedAt = $addedAt;
+        }
+
+        if (isset($lib['updatedAt'])) {
+            $updatedAt = new DateTime();
+            $updatedAt->setTimestamp($lib['updatedAt']);
+            $me->updatedAt = $updatedAt;
+        }
+
+        if (isset($lib['Genre']) && is_array($lib['Genre'])) {
+            if (count($lib['Genre']) == 1) {
+                $me->data['genre'][] = $lib['Genre']['tag'];
+            } else {
+                foreach ($lib['Genre'] as $g) {
+                    $me->data['genre'][] = $g['tag'];
+                }
+            }
+            unset($me->data['Genre']);
+        }
+
+        unset($me->data['Country']);
+
+        $res = $client->call($me->key);
+        if (isset($res['Directory']) && is_array($res['Directory']) && count($res['Directory'])) {
+            if (isset($res['Directory'][0])) {
+                foreach ($res['Directory'] as $a) {
+                    $a = Album::fromLibrary($a);
+                    $me->addAlbum($a);
+                }
+            } else {
+                $a = Album::fromLibrary($res['Directory']);
+                $me->addAlbum($a);
+            }
+        }
+
+        return $me;
+    }
+
+    /**
+     * Serialize the object
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->data;
+    }
+}

--- a/src/jc21/Music/Artist.php
+++ b/src/jc21/Music/Artist.php
@@ -6,6 +6,7 @@ use DateTime;
 use Exception;
 use JsonSerializable;
 use jc21\Util\Item;
+use jc21\Collections\ItemCollection;
 
 /**
  * Artist
@@ -39,16 +40,16 @@ class Artist implements Item, JsonSerializable
     /**
      * Array to store albums
      *
-     * @var array:Album
+     * @var ItemCollection
      */
-    private array $albums;
+    private ItemCollection $albums;
 
     /**
      * Constructor
      */
     public function __construct()
     {
-        $this->albums = [];
+        $this->albums = new ItemCollection();
     }
 
     /**
@@ -79,13 +80,23 @@ class Artist implements Item, JsonSerializable
     }
 
     /**
+     * Method to retrieve the albums this artist has released
+     * 
+     * @return ItemCollection
+     */
+    public function getChildren(): ItemCollection
+    {
+        return $this->albums;
+    }
+
+    /**
      * Method to add album
      *
      * @param Album $a
      */
     public function addAlbum(Album $a)
     {
-        $this->albums[] = $a;
+        $this->albums->addData($a);
     }
 
     /**

--- a/src/jc21/Music/Track.php
+++ b/src/jc21/Music/Track.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace jc21\Music;
+
+use DateTime;
+use JsonSerializable;
+use jc21\Util\Duration;
+use jc21\Util\Item;
+use jc21\Util\Media;
+
+/**
+ * Music track data
+ *
+ * @property int $ratingKey
+ * @property int $parentRatingKey
+ * @property int $grandparentRatingKey
+ * @property string $key
+ * @property string $parentKey
+ * @property string $grandparentKey
+ * @property string $guid
+ * @property string $parentGuid
+ * @property string $grandparentGuid
+ * @property string $type
+ * @property string $title
+ * @property string $parentTitle
+ * @property string $grandparentTitle
+ * @property string $parentStudio
+ * @property string $summary
+ * @property int $index
+ * @property int $parentIndex
+ * @property int $ratingCount
+ * @property int $parentYear
+ * @property string $thumb
+ * @property string $parentThumb
+ * @property string $grandparentThumb
+ * @property Duration $duration
+ * @property DateTime $addedAt
+ * @property DateTime $updatedAt
+ * @property Media $media
+ */
+class Track implements Item, JsonSerializable
+{
+    /**
+     * Class data
+     *
+     * @var array
+     */
+    private array $data;
+
+    /**
+     * Magic getter
+     *
+     * @param string $var
+     *
+     * @return mixed
+     */
+    public function __get(string $var)
+    {
+        if (isset($this->data[$var])) {
+            return $this->data[$var];
+        }
+        return null;
+    }
+
+    /**
+     * Magic setter
+     *
+     * @param string $var
+     * @param mixed $val
+     */
+    public function __set(string $var, $val)
+    {
+        $this->data[$var] = $val;
+    }
+
+    /**
+     * Method to create an object from the library
+     *
+     * @param array $lib
+     *
+     * @return Track
+     */
+    public static function fromLibrary(array $lib): Track
+    {
+        $me = new static();
+        $me->data = $lib;
+
+        if (isset($lib['addedAt'])) {
+            $addedAt = new DateTime();
+            $addedAt->setTimestamp($lib['addedAt']);
+            $me->addedAt = $addedAt;
+        }
+
+        if (isset($lib['updatedAt'])) {
+            $updatedAt = new DateTime();
+            $updatedAt->setTimestamp($lib['updatedAt']);
+            $me->updatedAt = $updatedAt;
+        }
+
+        if (isset($lib['duration'])) {
+            $me->duration = new Duration($lib['duration']);
+        }
+
+        if (isset($lib['Media'])) {
+            $me->media = Media::fromLibrary($lib['Media']);
+            unset($lib['Media']);
+        }
+
+        return $me;
+    }
+
+    /**
+     * Method to serialize the object
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->data;
+    }
+}

--- a/src/jc21/PlexApi.php
+++ b/src/jc21/PlexApi.php
@@ -5,7 +5,6 @@ namespace jc21;
 use jc21\Collections\ItemCollection;
 use jc21\Movies\Movie;
 use jc21\TV\Show;
-use jc21\Util\Item;
 
 /**
  * Plex API Class - Communicate with your Plex Media Server.
@@ -682,20 +681,22 @@ class PlexApi
 
     /**
      * Method to check the results for what is expected
-     * 
+     *
      * @param array $results
      * @param bool $returnCollection
-     * 
+     *
      * @return ItemCollection|bool|array
      */
     private function checkResults($results, bool $returnCollection)
     {
-        if (is_bool($results) || !$returnCollection): return $results; endif;
+        if (is_bool($results) || !$returnCollection): return $results;
+        endif;
 
         $tag = (isset($results['Video']) ? 'Video' : null);
         $tag = (isset($results['Directory']) ? 'Directory' : $tag);
 
-        if (is_null($tag)): return false; endif;
+        if (is_null($tag)): return false;
+        endif;
 
         return $this->array2collection($results[$tag]);
     }

--- a/src/jc21/PlexApi.php
+++ b/src/jc21/PlexApi.php
@@ -226,6 +226,15 @@ class PlexApi
         return $this->call('/transcode/sessions');
     }
 
+    /**
+     * Method to get plex account data
+     *
+     * @return array|bool
+     */
+    public function getAccount()
+    {
+        return $this->call('/myplex/account');
+    }
 
     /**
      * Get On Deck Info

--- a/src/jc21/PlexApi.php
+++ b/src/jc21/PlexApi.php
@@ -234,18 +234,7 @@ class PlexApi
     {
         $results = $this->call('/library/onDeck');
 
-        if (is_bool($results)) {
-            return $results;
-        }
-
-        if (is_bool($results) || !$returnCollection): return $results; endif;
-
-        $tag = (isset($results['Video']) ? 'Video' : null);
-        $tag = (isset($results['Directory']) ? 'Directory' : $tag);
-
-        if (is_null($tag)): return false; endif;
-
-        return $this->array2collection($results[$tag]);
+        return $this->checkResults($results, $returnCollection);
     }
 
 
@@ -271,14 +260,7 @@ class PlexApi
     {
         $results = $this->call('/library/sections/' . $sectionKey . '/all');
 
-        if (is_bool($results) || !$returnCollection): return $results; endif;
-
-        $tag = (isset($results['Video']) ? 'Video' : null);
-        $tag = (isset($results['Directory']) ? 'Directory' : $tag);
-
-        if (is_null($tag)): return false; endif;
-
-        return $this->array2collection($results[$tag]);
+        return $this->checkResults($results, $returnCollection);
     }
 
 
@@ -332,14 +314,7 @@ class PlexApi
     {
         $results = $this->call('/library/recentlyAdded');
 
-        if (is_bool($results) || !$returnCollection): return $results; endif;
-
-        $tag = (isset($results['Video']) ? 'Video' : null);
-        $tag = (isset($results['Directory']) ? 'Directory' : $tag);
-
-        if (is_null($tag)): return false; endif;
-
-        return $this->array2collection($results[$tag]);
+        return $this->checkResults($results, $returnCollection);
     }
 
 
@@ -367,14 +342,7 @@ class PlexApi
     {
         $results = $this->call('/search', ['query' => $query]);
 
-        if (is_bool($results) || !$returnCollection): return $results; endif;
-
-        $tag = (isset($results['Video']) ? 'Video' : null);
-        $tag = (isset($results['Directory']) ? 'Directory' : $tag);
-
-        if (is_null($tag)): return false; endif;
-
-        return $this->array2collection($results[$tag]);
+        return $this->checkResults($results, $returnCollection);
     }
 
     /**
@@ -390,14 +358,7 @@ class PlexApi
     {
         $results = $this->call("/library/sections/{$sectionKey}/all", $filter);
 
-        if (is_bool($results) || !$returnCollection): return $results; endif;
-
-        $tag = (isset($results['Video']) ? 'Video' : null);
-        $tag = (isset($results['Directory']) ? 'Directory' : $tag);
-
-        if (is_null($tag)): return false; endif;
-
-        return $this->array2collection($results[$tag]);
+        return $this->checkResults($results, $returnCollection);
     }
 
     /**
@@ -717,5 +678,25 @@ class PlexApi
         } else {
             $result = $data;
         }
+    }
+
+    /**
+     * Method to check the results for what is expected
+     * 
+     * @param array $results
+     * @param bool $returnCollection
+     * 
+     * @return ItemCollection|bool|array
+     */
+    private function checkResults($results, bool $returnCollection)
+    {
+        if (is_bool($results) || !$returnCollection): return $results; endif;
+
+        $tag = (isset($results['Video']) ? 'Video' : null);
+        $tag = (isset($results['Directory']) ? 'Directory' : $tag);
+
+        if (is_null($tag)): return false; endif;
+
+        return $this->array2collection($results[$tag]);
     }
 }

--- a/src/jc21/PlexApi.php
+++ b/src/jc21/PlexApi.php
@@ -36,6 +36,7 @@ class PlexApi
     // Plex agents
     public const PLEX_AGENT_NONE = 'com.plexapp.agents.none';
     public const PLEX_MOVIE_AGENT = 'tv.plex.agents.movie';
+    public const PLEX_IMDB_MOVIE_AGENT = 'com.plexapp.agents.imdb';
     public const PLEX_TV_AGENT = 'tv.plex.agents.series';
     public const PLEX_MUSIC_AGENT = 'tv.plex.agents.music';
 
@@ -237,12 +238,14 @@ class PlexApi
             return $results;
         }
 
+        if (is_bool($results) || !$returnCollection): return $results; endif;
+
         $tag = (isset($results['Video']) ? 'Video' : null);
         $tag = (isset($results['Directory']) ? 'Directory' : $tag);
 
         if (is_null($tag)): return false; endif;
 
-        return ($returnCollection ? $this->array2collection($results[$tag]) : $results);
+        return $this->array2collection($results[$tag]);
     }
 
 
@@ -268,16 +271,14 @@ class PlexApi
     {
         $results = $this->call('/library/sections/' . $sectionKey . '/all');
 
-        if (is_bool($results)) {
-            return $results;
-        }
+        if (is_bool($results) || !$returnCollection): return $results; endif;
 
         $tag = (isset($results['Video']) ? 'Video' : null);
         $tag = (isset($results['Directory']) ? 'Directory' : $tag);
 
         if (is_null($tag)): return false; endif;
 
-        return ($returnCollection ? $this->array2collection($results[$tag]) : $results);
+        return $this->array2collection($results[$tag]);
     }
 
 
@@ -331,16 +332,14 @@ class PlexApi
     {
         $results = $this->call('/library/recentlyAdded');
 
-        if (is_bool($results)) {
-            return $results;
-        }
+        if (is_bool($results) || !$returnCollection): return $results; endif;
 
         $tag = (isset($results['Video']) ? 'Video' : null);
         $tag = (isset($results['Directory']) ? 'Directory' : $tag);
 
         if (is_null($tag)): return false; endif;
 
-        return ($returnCollection ? $this->array2collection($results[$tag]) : $results);
+        return $this->array2collection($results[$tag]);
     }
 
 
@@ -368,16 +367,14 @@ class PlexApi
     {
         $results = $this->call('/search', ['query' => $query]);
 
-        if (is_bool($results)) {
-            return $results;
-        }
+        if (is_bool($results) || !$returnCollection): return $results; endif;
 
         $tag = (isset($results['Video']) ? 'Video' : null);
         $tag = (isset($results['Directory']) ? 'Directory' : $tag);
 
         if (is_null($tag)): return false; endif;
 
-        return ($returnCollection ? $this->array2collection($results[$tag]) : $results);
+        return $this->array2collection($results[$tag]);
     }
 
     /**
@@ -393,16 +390,14 @@ class PlexApi
     {
         $results = $this->call("/library/sections/{$sectionKey}/all", $filter);
 
-        if (is_bool($results)) {
-            return $results;
-        }
+        if (is_bool($results) || !$returnCollection): return $results; endif;
 
         $tag = (isset($results['Video']) ? 'Video' : null);
         $tag = (isset($results['Directory']) ? 'Directory' : $tag);
 
         if (is_null($tag)): return false; endif;
 
-        return ($returnCollection ? $this->array2collection($results[$tag]) : $results);
+        return $this->array2collection($results[$tag]);
     }
 
     /**

--- a/src/jc21/PlexApi.php
+++ b/src/jc21/PlexApi.php
@@ -549,6 +549,9 @@ class PlexApi
     {
         if (!$this->token && !$isLoginCall) {
             $this->call('https://plex.tv/users/sign_in.xml', [], self::POST, true);
+            if (!$this->token) {
+                return false;
+            }
         }
 
         if ($isLoginCall) {

--- a/src/jc21/PlexApi.php
+++ b/src/jc21/PlexApi.php
@@ -237,10 +237,10 @@ class PlexApi
             return $results;
         }
 
-        $tag = 'Video';
-        if (!isset($results[$tag]) && isset($results['Directory'])) {
-            $tag = 'Directory';
-        }
+        $tag = (isset($results['Video']) ? 'Video' : null);
+        $tag = (isset($results['Directory']) ? 'Directory' : $tag);
+
+        if (is_null($tag)): return false; endif;
 
         return ($returnCollection ? $this->array2collection($results[$tag]) : $results);
     }
@@ -272,10 +272,10 @@ class PlexApi
             return $results;
         }
 
-        $tag = 'Video';
-        if (!isset($results[$tag]) && isset($results['Directory'])) {
-            $tag = 'Directory';
-        }
+        $tag = (isset($results['Video']) ? 'Video' : null);
+        $tag = (isset($results['Directory']) ? 'Directory' : $tag);
+
+        if (is_null($tag)): return false; endif;
 
         return ($returnCollection ? $this->array2collection($results[$tag]) : $results);
     }
@@ -335,10 +335,10 @@ class PlexApi
             return $results;
         }
 
-        $tag = 'Video';
-        if (!isset($results[$tag]) && isset($results['Directory'])) {
-            $tag = 'Directory';
-        }
+        $tag = (isset($results['Video']) ? 'Video' : null);
+        $tag = (isset($results['Directory']) ? 'Directory' : $tag);
+
+        if (is_null($tag)): return false; endif;
 
         return ($returnCollection ? $this->array2collection($results[$tag]) : $results);
     }
@@ -372,10 +372,10 @@ class PlexApi
             return $results;
         }
 
-        $tag = 'Video';
-        if (!isset($results[$tag]) && isset($results['Directory'])) {
-            $tag = 'Directory';
-        }
+        $tag = (isset($results['Video']) ? 'Video' : null);
+        $tag = (isset($results['Directory']) ? 'Directory' : $tag);
+
+        if (is_null($tag)): return false; endif;
 
         return ($returnCollection ? $this->array2collection($results[$tag]) : $results);
     }
@@ -397,10 +397,10 @@ class PlexApi
             return $results;
         }
 
-        $tag = 'Video';
-        if (!isset($results[$tag]) && isset($results['Directory'])) {
-            $tag = 'Directory';
-        }
+        $tag = (isset($results['Video']) ? 'Video' : null);
+        $tag = (isset($results['Directory']) ? 'Directory' : $tag);
+
+        if (is_null($tag)): return false; endif;
 
         return ($returnCollection ? $this->array2collection($results[$tag]) : $results);
     }

--- a/src/jc21/PlexApi.php
+++ b/src/jc21/PlexApi.php
@@ -254,11 +254,23 @@ class PlexApi
     /**
      * Get Library Sections ie Movies, TV Shows etc
      *
+     * @param bool $returnObjects
+     *
      * @return array|bool
      */
-    public function getLibrarySections()
+    public function getLibrarySections(bool $returnObjects = false)
     {
-        return $this->call('/library/sections');
+        $res = $this->call('/library/sections');
+        if (!$returnObjects): return $res;
+        endif;
+
+        $ret = [];
+        foreach ($res['Directory'] as $s) {
+            $sec = Section::fromLibrary($s);
+            $ret[] = $sec;
+        }
+
+        return $ret;
     }
 
     /**

--- a/src/jc21/TV/Episode.php
+++ b/src/jc21/TV/Episode.php
@@ -172,7 +172,7 @@ class Episode implements Item, JsonSerializable
         }
 
         if (isset($lib['Writer']) && is_array($lib['Writer'])) {
-            if (count($lib['Writer']) == 1) {
+            if (isset($lib['Writer']['tag'])) {
                 $me->data['writer'][] = $lib['Writer']['tag'];
             } else {
                 foreach ($lib['Writer'] as $w) {
@@ -183,7 +183,7 @@ class Episode implements Item, JsonSerializable
         }
 
         if (isset($lib['Role']) && is_array($lib['Role'])) {
-            if (count($lib['Role']) == 1) {
+            if (isset($lib['Role']['tag'])) {
                 $me->data['role'][] = $lib['Role']['tag'];
             } else {
                 foreach ($lib['Role'] as $r) {

--- a/src/jc21/TV/Episode.php
+++ b/src/jc21/TV/Episode.php
@@ -3,9 +3,10 @@
 namespace jc21\TV;
 
 use DateTime;
+use JsonSerializable;
 use jc21\Util\Media;
 use jc21\Util\Duration;
-use JsonSerializable;
+use jc21\Util\Item;
 
 /**
  * Class to store episode data
@@ -42,7 +43,7 @@ use JsonSerializable;
  * @property DateTime $updatedAt
  * @property Media $media
  */
-class Episode implements JsonSerializable
+class Episode implements Item, JsonSerializable
 {
     /**
      * Class data
@@ -124,7 +125,7 @@ class Episode implements JsonSerializable
      *
      * @return Episode
      */
-    public static function fromLibrary(array $lib)
+    public static function fromLibrary(array $lib): Episode
     {
         $me = new static();
         $me->data = $lib;
@@ -160,7 +161,7 @@ class Episode implements JsonSerializable
         }
 
         if (isset($lib['Director']) && is_array($lib['Director'])) {
-            if (count($lib['Director']) == 1) {
+            if (isset($lib['Director']['tag'])) {
                 $me->data['director'][] = $lib['Director']['tag'];
             } else {
                 foreach ($lib['Director'] as $d) {

--- a/src/jc21/TV/Season.php
+++ b/src/jc21/TV/Season.php
@@ -3,9 +3,9 @@
 namespace jc21\TV;
 
 use DateTime;
-use jc21\PlexApi;
 use JsonSerializable;
-use TypeError;
+use jc21\Collections\ItemCollection;
+use jc21\PlexApi;
 
 /**
  * To represent a season of a TV Show
@@ -45,9 +45,9 @@ class Season implements JsonSerializable
     /**
      * Array to store episodes of a show in a season
      *
-     * @var array:Episode
+     * @var ItemCollection
      */
-    private array $episodes;
+    private ItemCollection $episodes;
 
     /**
      * Constructor
@@ -109,9 +109,9 @@ class Season implements JsonSerializable
     /**
      * Method to return the episodes
      *
-     * @return array
+     * @return ItemCollection
      */
-    public function getEpisodes(): array
+    public function getChildren(): ItemCollection
     {
         return $this->episodes;
     }

--- a/src/jc21/TV/Season.php
+++ b/src/jc21/TV/Season.php
@@ -77,7 +77,7 @@ class Season implements JsonSerializable
             'addedAt' => null,
             'updatedAt' => null,
         ];
-        $this->episodes = [];
+        $this->episodes = new ItemCollection();
     }
 
     /**
@@ -123,7 +123,7 @@ class Season implements JsonSerializable
      */
     public function addEpisode(Episode $e)
     {
-        $this->episodes[$e->index] = $e;
+        $this->episodes->addData($e);
     }
 
     /**

--- a/src/jc21/Util/Duration.php
+++ b/src/jc21/Util/Duration.php
@@ -61,7 +61,7 @@ class Duration implements JsonSerializable
      *
      * @return mixed
      */
-    public function jsonSerialize(): mixed
+    public function jsonSerialize()
     {
         return (string) $this->duration;
     }

--- a/src/jc21/Util/Filter.php
+++ b/src/jc21/Util/Filter.php
@@ -43,7 +43,7 @@ class Filter
             throw new Exception("Invalid filter operator");
         }
 
-        if (!in_array($field, ['title', 'rating', 'contentRating', 'year', 'studio'])) {
+        if (!in_array($field, ['title', 'rating', 'contentRating', 'year', 'studio', 'resolution'])) {
             throw new Exception("Invalid filter field");
         }
 

--- a/src/jc21/Util/Location.php
+++ b/src/jc21/Util/Location.php
@@ -6,6 +6,9 @@ use JsonSerializable;
 
 /**
  * Object to store Location info
+ *
+ * @property int $id
+ * @property string $path
  */
 class Location implements JsonSerializable
 {

--- a/src/jc21/Util/Location.php
+++ b/src/jc21/Util/Location.php
@@ -53,7 +53,7 @@ class Location implements JsonSerializable
      *
      * @return mixed
      */
-    public function jsonSerialize(): mixed
+    public function jsonSerialize()
     {
         return $this->data;
     }

--- a/src/jc21/Util/Media.php
+++ b/src/jc21/Util/Media.php
@@ -44,7 +44,7 @@ class Media implements JsonSerializable
      *
      * @return mixed
      */
-    public function __get(string $var): mixed
+    public function __get(string $var)
     {
         if (isset($this->data[$var])) {
             return $this->data[$var];
@@ -99,7 +99,7 @@ class Media implements JsonSerializable
      *
      * @return mixed
      */
-    public function jsonSerialize(): mixed
+    public function jsonSerialize()
     {
         return $this->data;
     }

--- a/src/jc21/Util/Size.php
+++ b/src/jc21/Util/Size.php
@@ -25,6 +25,16 @@ class Size
     }
 
     /**
+     * Returns the size in TB
+     * 
+     * @return string
+     */
+    public function TB()
+    {
+        return number_format($this->size / 1024 / 1024 / 1024 / 1024, 3);
+    }
+
+    /**
      * Return the size in GB
      *
      * @return string

--- a/tests/ItemList.php
+++ b/tests/ItemList.php
@@ -1,0 +1,34 @@
+<?php
+
+require_once dirname(__DIR__).'/vendor/autoload.php';
+
+use jc21\PlexApi;
+use Symfony\Component\Dotenv\Dotenv;
+
+$dot = new Dotenv();
+$dot->loadEnv('tests/.env');
+
+$client = new PlexApi($_ENV['PLEX_HOST']);
+$client->setToken($_ENV['PLEX_TOKEN']);
+
+print PHP_EOL."Select one of the ID's below to put in your .env file for the *_ITEM_ID value".PHP_EOL;
+
+if (isset($_ENV['MOVIE_TESTS']) && (bool) $_ENV['MOVIE_TESTS']) {
+    print PHP_EOL."List of 10 Movies".PHP_EOL;
+    $movieCollection = $client->getLibrarySectionContents($_ENV['MOVIE_SECTION_KEY'], true);
+    for ($x = 0; $x < 10; $x++) {
+        $movie = $movieCollection->getData($x);
+        print "{$movie->ratingKey}: {$movie->title}".PHP_EOL;
+    }
+    print PHP_EOL;
+}
+
+if (isset($_ENV['TV_TESTS']) && (bool) $_ENV['TV_TESTS']) {
+    print "List of 10 TV shows".PHP_EOL;
+    $tvCollection = $client->getLibrarySectionContents($_ENV['TV_SECTION_KEY'], true);
+    for ($x = 0; $x < 10; $x++) {
+        $tv = $tvCollection->getData($x);
+        print "{$tv->ratingKey}: {$tv->title}".PHP_EOL;
+    }
+    print PHP_EOL;
+}

--- a/tests/PlexApiTest.php
+++ b/tests/PlexApiTest.php
@@ -119,8 +119,8 @@ class TestPlexApi extends TestCase
         $dot = new Dotenv();
 
         $envfname = __DIR__.'/.env';
-        if (!file_exists($envfname)) {
-            throw new \InvalidArgumentException(sprintf('%s does not exist', $envfname));
+        if (!file_exists($envfname) || !is_readable($envfname)) {
+            throw new \InvalidArgumentException(sprintf('%s does not exist or is not readable', $envfname));
         }
 
         $dot->loadEnv($envfname);

--- a/tests/PlexApiTest.php
+++ b/tests/PlexApiTest.php
@@ -2,13 +2,12 @@
 
 namespace jc21\PlexApi\Tests;
 
-use InvalidArgumentException;
-use jc21\Collections\ItemCollection;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Dotenv\Dotenv;
 
 use jc21\PlexApi;
 use jc21\Util\Filter;
+use jc21\Collections\ItemCollection;
 
 /**
  * @coversDefaultClass PlexApi
@@ -18,17 +17,51 @@ class TestPlexApi extends TestCase
 
     /**
      * Api to check
+     * 
+     * @var PlexApi
      */
     private ?PlexApi $api;
 
+    /**
+     * Plex.tv username
+     * 
+     * @var string
+     */
     private string $user;
 
+    /**
+     * Plex.tv password
+     * 
+     * @var string
+     */
     private string $password;
 
+    /**
+     * Local Plex server
+     * 
+     * @var string
+     */
     private string $host;
 
+    /**
+     * Port to connect to Plex through
+     * 
+     * @var int
+     */
     private int $port;
 
+    /**
+     * Connect to Plex through SSL
+     * 
+     * @var bool
+     */
+    private bool $ssl;
+
+    /**
+     * Plex token for authentication
+     * 
+     * @var string
+     */
     private string $token;
 
     /**
@@ -67,6 +100,7 @@ class TestPlexApi extends TestCase
         $this->user = (isset($_ENV['PLEX_USER']) ? $_ENV['PLEX_USER'] : false);
         $this->password = (isset($_ENV['PLEX_PASSWORD']) ? $_ENV['PLEX_PASSWORD'] : false);
         $this->port = (isset($_ENV['PLEX_PORT']) ? $_ENV['PLEX_PORT'] : false);
+        $this->ssl = (isset($_ENV['PLEX_SSL']) ? (bool) $_ENV['PLEX_SSL'] : false);
         $ret = true;
 
         if ($this->host === false) {

--- a/tests/PlexApiTest.php
+++ b/tests/PlexApiTest.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace jc21\PlexApi\Tests;
+
+use InvalidArgumentException;
+use jc21\Collections\ItemCollection;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Dotenv\Dotenv;
+
+use jc21\PlexApi;
+use jc21\Util\Filter;
+
+/**
+ * @coversDefaultClass PlexApi
+ */
+class TestPlexApi extends TestCase
+{
+
+    /**
+     * Api to check
+     */
+    private ?PlexApi $api;
+
+    private string $user;
+
+    private string $password;
+
+    private string $host;
+
+    private int $port;
+
+    private string $token;
+
+    /**
+     * Setup function
+     */
+    public function setUp(): void
+    {
+        $dot = new Dotenv();
+
+        $envfname = __DIR__.'/.env';
+        if(!file_exists($envfname)) {
+            throw new \InvalidArgumentException(sprintf('%s does not exist', $envfname));
+        }
+
+        $dot->loadEnv($envfname);
+
+        $this->api = null;
+        if(!$this->envCheck()) {
+            die;
+        }
+
+        $this->api = new PlexApi($this->host, $this->port, $this->ssl);
+        if ($this->token) {
+            $this->api->setToken($this->token);
+        } else {
+            $this->api->setAuth($this->user, $this->password);
+
+            throw new \Exception("Put this token in your .env file {$envfname} as 'PLEX_TOKEN={$this->api->getToken()}'");
+        }
+    }
+
+    private function envCheck()
+    {
+        $this->host = (isset($_ENV['PLEX_HOST']) ? $_ENV['PLEX_HOST'] : false);
+        $this->token = (isset($_ENV['PLEX_TOKEN']) ? $_ENV['PLEX_TOKEN'] : false);
+        $this->user = (isset($_ENV['PLEX_USER']) ? $_ENV['PLEX_USER'] : false);
+        $this->password = (isset($_ENV['PLEX_PASSWORD']) ? $_ENV['PLEX_PASSWORD'] : false);
+        $this->port = (isset($_ENV['PLEX_PORT']) ? $_ENV['PLEX_PORT'] : false);
+        $ret = true;
+
+        if ($this->host === false) {
+            print("PLEX_HOST not found in .env file".PHP_EOL);
+        }
+
+        if ($this->token === false && ($this->user === false || $this->password === false)) {
+            print("PLEX_TOKEN not found in .env file".PHP_EOL);
+            $ret = false;
+        }
+
+        if (!isset($_ENV['SECTION_KEY']) || !is_numeric($_ENV['SECTION_KEY'])) {
+            print("SECTION_KEY not found or not INT in .env, populate with ID of library you want to test".PHP_EOL);
+            $ret = false;
+        }
+
+        if (!isset($_ENV['ITEM_ID']) || !is_numeric($_ENV['ITEM_ID'])) {
+            print("ITEM_ID not found or not INT in .env".PHP_EOL);
+            $ret = false;
+        }
+
+        if (!isset($_ENV['SEARCH_QUERY'])) {
+            print("SEARCH_QUERY not found in .env".PHP_EOL);
+            $ret = false;
+        }
+
+        if (!isset($_ENV['FILTER_QUERY'])) {
+            print("FILTER_QUERY not found in .env, MUST be a title filter".PHP_EOL);
+            $ret = false;
+        }
+
+        return $ret;
+    }
+
+    public function testConnection()
+    {
+        $this->assertTrue(is_a($this->api, "jc21\PlexApi"));
+    }
+
+    public function testGetSessions()
+    {
+        $this->assertArrayHasKey('size', $this->api->getSessions());
+    }
+
+    public function testOnDeck()
+    {
+        $od = $this->api->getOnDeck();
+        $this->assertArrayHasKey('size', $od);
+    }
+
+    public function testOnDeckReturnCollection()
+    {
+        $od = $this->api->getOnDeck(true);
+        $this->assertInstanceOf(ItemCollection::class, $od);
+    }
+
+    public function testOnDeckHasItems()
+    {
+        $od = $this->api->getOnDeck(true);
+        $this->assertGreaterThan(0, $od->count());
+    }
+
+    public function testGetSections()
+    {
+        $sec = $this->api->getLibrarySections();
+        $this->assertArrayHasKey('size', $sec);
+
+        $this->assertGreaterThan(0, $sec['size']);
+    }
+
+    public function testGetLibrarySectionContents()
+    {
+        $res = $this->api->getLibrarySectionContents($_ENV['SECTION_KEY']);
+        $this->assertArrayHasKey('size', $res);
+
+        $this->assertGreaterThan(0, $res['size']);
+    }
+
+    public function testGetLibrarySectionContentsAsCollection()
+    {
+        $res = $this->api->getLibrarySectionContents($_ENV['SECTION_KEY'], true);
+        $this->assertInstanceOf(ItemCollection::class, $res);
+
+        $this->assertGreaterThan(0, $res->count());
+    }
+
+    public function testGetRecentlyAdded()
+    {
+        $res = $this->api->getRecentlyAdded();
+        $this->assertIsArray($res);
+
+        $this->assertArrayHasKey('size', $res);
+
+        $this->assertGreaterThan(0, $res['size']);
+    }
+
+    public function testGetMetadata()
+    {
+        $res = $this->api->getMetadata($_ENV['ITEM_ID']);
+        $this->assertIsArray($res);
+        $this->assertArrayHasKey('size', $res);
+        $this->assertGreaterThan(0, $res['size']);
+    }
+
+    public function testSearch()
+    {
+        $res = $this->api->search($_ENV['SEARCH_QUERY']);
+        $this->assertIsArray($res);
+        $this->assertArrayHasKey('size', $res);
+        $this->assertGreaterThan(0, $res['size']);
+    }
+
+    public function testSearchReturnCollection()
+    {
+        $res = $this->api->search($_ENV['SEARCH_QUERY'], true);
+        $this->assertInstanceOf(ItemCollection::class, $res);
+        $this->assertGreaterThan(0, $res->count());
+    }
+
+    public function testFilter()
+    {
+        $res = $this->api->filter($_ENV['SECTION_KEY'], ['title' => $_ENV['FILTER_QUERY']]);
+        $this->assertIsArray($res);
+        $this->assertArrayHasKey('size', $res);
+        $this->assertGreaterThan(0, $res['size']);
+    }
+
+    public function testFilterWithFilterObject()
+    {
+        $filter = new Filter('title', $_ENV['FILTER_QUERY']);
+        $res = $this->api->filter($_ENV['SECTION_KEY'], [$filter]);
+        $this->assertIsArray($res);
+        $this->assertArrayHasKey('size', $res);
+        $this->assertGreaterThan(0, $res['size']);
+    }
+
+    public function testFilterReturnCollection()
+    {
+        $res = $this->api->filter($_ENV['SECTION_KEY'], ['title' => $_ENV['FILTER_QUERY']], true);
+        $this->assertInstanceOf(ItemCollection::class, $res);
+        $this->assertGreaterThan(0, $res->count());
+    }
+
+    public function testFilterWithFilterObjectReturnCollection()
+    {
+        $filter = new Filter('title', $_ENV['FILTER_QUERY']);
+        $res = $this->api->filter($_ENV['SECTION_KEY'], [$filter], true);
+        $this->assertInstanceOf(ItemCollection::class, $res);
+        $this->assertGreaterThan(0, $res->count());
+    }
+
+    public function testGetMatches()
+    {
+        $res = $this->api->getMatches($_ENV['ITEM_ID']);
+        $this->assertIsArray($res);
+        $this->assertArrayHasKey('size', $res);
+        $this->assertGreaterThan(0, $res['size']);
+    }
+}

--- a/tests/PlexApiTest.php
+++ b/tests/PlexApiTest.php
@@ -8,6 +8,7 @@ use Symfony\Component\Dotenv\Dotenv;
 use jc21\PlexApi;
 use jc21\Util\Filter;
 use jc21\Collections\ItemCollection;
+use jc21\Section;
 use jc21\TV\Episode;
 
 /**
@@ -295,6 +296,14 @@ class TestPlexApi extends TestCase
         $this->assertGreaterThan(0, $sec['size']);
     }
 
+    public function testGetSectionsAsObject()
+    {
+        $secs = $this->api->getLibrarySections(true);
+        $this->assertIsArray($secs);
+        $this->assertIsObject($secs[0]);
+        $this->assertInstanceOf(Section::class, $secs[0]);
+    }
+
     public function testGetMovieLibrarySectionContents()
     {
         if (!$this->runMovieTests) {
@@ -317,6 +326,19 @@ class TestPlexApi extends TestCase
         $res = $this->api->getLibrarySectionContents($_ENV['MOVIE_SECTION_KEY'], true);
         $this->assertInstanceOf(ItemCollection::class, $res);
         $this->assertGreaterThan(0, $res->count());
+    }
+
+    public function testGetMovieCollectionSize()
+    {
+        if (!$this->runMovieTests) {
+            $this->markTestSkipped(self::MOVIE_OFF_MSG);
+            return;
+        }
+
+        $filter = new Filter('title', $_ENV['MOVIE_FILTER_QUERY']);
+        $res = $this->api->filter($_ENV['MOVIE_SECTION_KEY'], [$filter], true);
+        
+        $this->assertEquals($_ENV['MOVIE_FILTER_QUERY_SIZE'], $res->size()->bytes());
     }
 
     public function testGetMetadata()

--- a/tests/PlexApiTest.php
+++ b/tests/PlexApiTest.php
@@ -241,6 +241,22 @@ class TestPlexApi extends TestCase
         $this->assertTrue(is_a($this->api, "jc21\PlexApi"));
     }
 
+    public function testGetBaseInfo()
+    {
+        $res = $this->api->getBaseInfo();
+        $this->assertIsArray($res);
+        $this->assertArrayHasKey('size', $res);
+        $this->assertGreaterThan(0, $res['size']);
+    }
+
+    public function testGetAccount()
+    {
+        $res = $this->api->getAccount();
+        $this->assertIsArray($res);
+        $this->assertArrayHasKey('signInState', $res);
+        $this->assertEquals('ok', $res['signInState']);
+    }
+
     public function testGetSessions()
     {
         $this->assertArrayHasKey('size', $this->api->getSessions());

--- a/tests/PlexApiTest.php
+++ b/tests/PlexApiTest.php
@@ -17,49 +17,49 @@ class TestPlexApi extends TestCase
 
     /**
      * Api to check
-     * 
+     *
      * @var PlexApi
      */
     private ?PlexApi $api;
 
     /**
      * Plex.tv username
-     * 
+     *
      * @var string
      */
     private string $user;
 
     /**
      * Plex.tv password
-     * 
+     *
      * @var string
      */
     private string $password;
 
     /**
      * Local Plex server
-     * 
+     *
      * @var string
      */
     private string $host;
 
     /**
      * Port to connect to Plex through
-     * 
+     *
      * @var int
      */
     private int $port;
 
     /**
      * Connect to Plex through SSL
-     * 
+     *
      * @var bool
      */
     private bool $ssl;
 
     /**
      * Plex token for authentication
-     * 
+     *
      * @var string
      */
     private string $token;
@@ -72,14 +72,14 @@ class TestPlexApi extends TestCase
         $dot = new Dotenv();
 
         $envfname = __DIR__.'/.env';
-        if(!file_exists($envfname)) {
+        if (!file_exists($envfname)) {
             throw new \InvalidArgumentException(sprintf('%s does not exist', $envfname));
         }
 
         $dot->loadEnv($envfname);
 
         $this->api = null;
-        if(!$this->envCheck()) {
+        if (!$this->envCheck()) {
             die;
         }
 
@@ -93,6 +93,11 @@ class TestPlexApi extends TestCase
         }
     }
 
+    /**
+     * Helper method to check available environment variables
+     *
+     * @return bool
+     */
     private function envCheck()
     {
         $this->host = (isset($_ENV['PLEX_HOST']) ? $_ENV['PLEX_HOST'] : false);
@@ -167,7 +172,6 @@ class TestPlexApi extends TestCase
     {
         $sec = $this->api->getLibrarySections();
         $this->assertArrayHasKey('size', $sec);
-
         $this->assertGreaterThan(0, $sec['size']);
     }
 
@@ -175,7 +179,6 @@ class TestPlexApi extends TestCase
     {
         $res = $this->api->getLibrarySectionContents($_ENV['SECTION_KEY']);
         $this->assertArrayHasKey('size', $res);
-
         $this->assertGreaterThan(0, $res['size']);
     }
 
@@ -183,7 +186,6 @@ class TestPlexApi extends TestCase
     {
         $res = $this->api->getLibrarySectionContents($_ENV['SECTION_KEY'], true);
         $this->assertInstanceOf(ItemCollection::class, $res);
-
         $this->assertGreaterThan(0, $res->count());
     }
 
@@ -191,9 +193,7 @@ class TestPlexApi extends TestCase
     {
         $res = $this->api->getRecentlyAdded();
         $this->assertIsArray($res);
-
         $this->assertArrayHasKey('size', $res);
-
         $this->assertGreaterThan(0, $res['size']);
     }
 

--- a/tests/SectionList.php
+++ b/tests/SectionList.php
@@ -1,0 +1,18 @@
+<?php
+
+require_once dirname(__DIR__).'/vendor/autoload.php';
+
+use jc21\PlexApi;
+use Symfony\Component\Dotenv\Dotenv;
+
+$dot = new Dotenv();
+$dot->loadEnv("tests/.env");
+
+$client = new PlexApi($_ENV['PLEX_HOST']);
+$client->setToken($_ENV['PLEX_TOKEN']);
+$result = $client->getLibrarySections();
+
+foreach ($result['Directory'] as $section) {
+    // Output
+    print "{$section['key']}: {$section['title']} (type: {$section['type']})".PHP_EOL;
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+require dirname(__DIR__) . "/vendor/autoload.php";


### PR DESCRIPTION
Made the fixes that delovelady asked about in issue #13 & #14 .  Also, added parsing for Music libraries.  Photo libraries are going to need a lot of thought before implementing that.  Lastly, fixed some other various bugs and added PHPUnit and Dotenv for dev unit testing.

I also added a call to the `/myplex/account` that was asked for in #11 .  #8 should also be fixed because I never saw the issue in my testing.  I also added delovelady's code snippet in his last comment.

To do unit tests, update to this version, then run `composer test`.  The setup method will check your environment variables and tell you want to do next.  I set up a `.env` file in the tests directory that looks like this.

```
#[Server]
PLEX_HOST={IP of Plex server}
PLEX_PORT={Port Plex is running on}
PLEX_TOKEN={Plex Token}
###  If you don't know your Plex token you'll have to put in your username and password as below
#PLEX_USER={Plex username}
#PLEX_PASSWORD={Plex password}

PLEX_SSL=0 or 1 # if you're using SSL for your Plex server

#[Movies]
MOVIE_TESTS=0|1    # do you want to run the tests for the movie environment, if not, rest of the MOVIE_\* can be left out
MOVIE_SECTION_KEY={section key id}    # can be found by running `composer section`
MOVIE_ITEM_ID={Item id that is used in queries}  # run `composer item` to see what is available once you've put in a section key
MOVIE_SEARCH_QUERY={movie title}   # a title string that should result in finding a movie (case-insensitive, if non-alphanumeric present surround with double-quotes)
MOVIE_FILTER_QUERY={movie title}       # a title string that can used to filter for a movie (case-sensitive, might present a problem if too ambiguous, if non-alphanumeric present surround with double-quotes)
MOVIE_FILTER_QUERY_SIZE={size in bytes}    #of the movie from MOVIE_FILTER_QUERY

#[TV]
TV_TESTS=0|1    # do you want to run the tests for the TV environment, if not, rest of the TV_\* can be omitted
TV_SECTION_KEY={section key id}   # can be found by running `composer section`
TV_ITEM_ID={item id that is used in queries}   # run `composer item` once you've put in a section key to see 10 options
TV_SEARCH_QUERY={episode title}   # episode title that can be used in query (case-insensitive, if non-alphanumeric surround present with double-quotes)
TV_FILTER_QUERY={show or episode query}   # title of show or episode used in filtering (case-sensitive, if non-alphanumeric present surround with double-quotes)

#[Music]
MUSIC_TESTS=0|1   # do you want to run the tests for the music environment, if not rest of MUSIC_\* can be omitted
MUSIC_SECTION_KEY={section key id}  # can be found by running `composer section`
MUSIC_SEARCH_QUERY={search string}   # artist/album/track search string (if non-alphanumeric present, surround with double-quotes)
MUSIC_FILTER_QUERY={search string}   # artist/album/track query string (case-sensitive, if non-alphanumeric present, surround with double-quotes)
```