### PR TITLE
Remove redundant curl_close in PlexApi.php

### DIFF
--- a/src/jc21/PlexApi.php
+++ b/src/jc21/PlexApi.php
@@ -637,7 +637,6 @@ class PlexApi
             }
         }
 
-        curl_close($resource);
         return $response;
     }
 


### PR DESCRIPTION
Removed unnecessary curl_close call before returning response.

PHP 8.5 deprecated curl_close()
See:
https://www.php.net/manual/en/function.curl-close.php
https://www.php.net/manual/en/migration85.deprecated.php